### PR TITLE
Enable automake subdir-objects option, to avoid possible future incompatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_CANONICAL_TARGET
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 
 # Check for programs
 AC_PROG_CC


### PR DESCRIPTION
Previously, I get this warning when building:

warning: source file 'google/protobuf/swift-descriptor.pb.cc' is in a subdirectory,
	but option 'subdir-objects' is disabled

automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.

Additionally, when doing this build within Xcode as part of my larger project, Xcode complains that errors were emitted without a nonzero exit status (ie. it works anyway)

I don’t know much about autotools, but I saw another project doing this, and it seems to fix it.
(Sidenote – I really like CMake better, and am using CMake to build protobuf 3 itself on OS X, Linux and Windows. One day I might make CMake files for protobuf-swift.)