### PR TITLE
Fix enum type qualification

### DIFF
--- a/src/compiler/swift_helpers.cc
+++ b/src/compiler/swift_helpers.cc
@@ -386,7 +386,7 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
         string name = PackageName(descriptor);
 
         if (descriptor->containing_type() != NULL) {
-            name = ClassNameWorker(descriptor->containing_type());
+            name += ClassNameWorker(descriptor->containing_type());
             name += ".";
         }
    


### PR DESCRIPTION
When an enum from one package is used within a different package, the generated Swift code does not qualify the enum with its package name.