### PR TITLE
Update Homebrew formula

### DIFF
--- a/protobuf-swift.rb
+++ b/protobuf-swift.rb
@@ -1,14 +1,23 @@
 class ProtobufSwift < Formula
   desc "Implementation of Protocol Buffers in Swift."
   homepage "https://github.com/alexeyxo/protobuf-swift"
-  url "https://github.com/alexeyxo/protobuf-swift/archive/2.1.tar.gz"
-  sha256 "7022720fc89cfe3d988728d62e9af2869ac072f6a2be6acc3fc6cbaa939aa220"
+
+  stable do
+    url "https://github.com/alexeyxo/protobuf-swift/archive/2.2.tar.gz"
+    sha256 "652173269234f2c6bbe37b85d8772823a323f5379cef48fa33a96237c1148682"
+  end
+
+  devel do
+    url "https://github.com/alexeyxo/protobuf-swift/archive/565699c74ec2207f600d10f24c76ae0f2b6abc2a.zip"
+    sha256 "a8295e4c3148092e1f0dabd6ce68c4b34805b01ba6ea7d1ad95ea5bcda019ab7"
+    version "3.0-devel20150910"
+  end
 
   bottle do
     cellar :any
-    sha256 "b6123b83e9e49726eaf29f609904abb6d01817b376ae83a90260288ad0b0e46c" => :yosemite
-    sha256 "49b3db87574cd95f11a092b775dca548f2692733e5401a9e5ad4b605122516e7" => :mavericks
-    sha256 "b2fe475c59d1fa12b6af9f204bbe2b968a9972978c4a4d99f9330219b30a6516" => :mountain_lion
+    sha256 "64fc75e8b51eb1b571c03e79c2b75192767e153f2285ff213b0c52315e68f13f" => :yosemite
+    sha256 "529202f4904189cfe013a1bcb104c06a6bca4101536576b9c1c72082b504543f" => :mavericks
+    sha256 "3eb3d89eb2db1438d9cb4136b6e5bfb87313483a98908ae04cc3f0563169190e" => :mountain_lion
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
Updates formula to the current version used by Homebrew.
Additionally adds a "devel" block that allows using a version
of protobuf-swift from the "ProtoBuf3.0-Swift2.0" branch.

Thanks for the help getting this working, thought I'd send 
back the formula I used, in case you'd find this helpful.