### PR TITLE
Fix source_files and change version to 3.0.0

### DIFF
--- a/ProtocolBuffers-Swift.podspec
+++ b/ProtocolBuffers-Swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ProtocolBuffers-Swift"
-  s.version      = "1.6"
+  s.version      = "3.0.0"
   s.summary      = "Protocol Buffers for Swift"
   s.homepage     = "http://protobuf.io#swift"
   s.license      = "Apache 2.0"
@@ -10,17 +10,13 @@ Pod::Spec.new do |s|
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-
     Copyright 2008 Google Inc.
-
     LICENSE
   }
 
@@ -29,10 +25,12 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
+  s.watchos.deployment_target = '2.0'
+  s.tvos.deployment_target = '9.0'
 
   s.module_name = "ProtocolBuffers"
   s.source       = { :git => "https://github.com/alexeyxo/protobuf-swift.git", :tag => s.version }
-  s.source_files = 'src/ProtocolBuffers/runtime-pb-swift/*.{swift}'
+  s.source_files = 'Source/*.{swift}'
   s.requires_arc = true
   s.frameworks   = 'Foundation'
 end


### PR DESCRIPTION
Hi,

thanks for this great library! I've figured out, that the source_files path is incorrect in the ProtoBuf3.0-Swift2.0 branch.

Would be great if you can accept this PR.

Thanks,
Marc