### PR TITLE
Swift2.2

### DIFF
--- a/Source/CodedInputStream.swift
+++ b/Source/CodedInputStream.swift
@@ -422,7 +422,8 @@ public class CodedInputStream
             try refillBuffer(true)
         }
         let pointer = UnsafeMutablePointer<Int8>(buffer.mutableBytes)
-        let res = pointer[Int(bufferPos++)]
+        let res = pointer[Int(bufferPos)]
+        bufferPos += 1
         return res
     }
     
@@ -433,7 +434,7 @@ public class CodedInputStream
         }
         var result:Int32 = Int32(firstByte) & 0x7f
         var offset:Int32 = 7
-        for (; offset < 32; offset += 7) {
+        while (offset < 32) {
             var b:UInt8 = UInt8()
             guard inputStream.read(&b, maxLength: 1) > 0 else {
                 throw ProtocolBuffersError.InvalidProtocolBuffer("Truncated Message")
@@ -443,9 +444,11 @@ public class CodedInputStream
             if ((b & 0x80) == 0) {
                 return result
             }
+            
+            offset += 7
         }
         
-        for (; offset < 64; offset += 7) {
+        while (offset < 64) {
             var b:UInt8 = UInt8()
             guard inputStream.read(&b, maxLength: 1) > 0 else {
                 throw ProtocolBuffersError.InvalidProtocolBuffer("Truncated Message")
@@ -454,6 +457,8 @@ public class CodedInputStream
             if ((b & 0x80) == 0) {
                 return result
             }
+            
+            offset += 7
         }
         
         throw ProtocolBuffersError.InvalidProtocolBuffer("Truncated Message")
@@ -486,7 +491,7 @@ public class CodedInputStream
                     result |= (Int32(tmp) << 28);
                     if (tmp < 0) {
                         // Discard upper 32 bits.
-                        for (var i : Int = 0; i < 5; i++) {
+                        for _ in 0..<5 {
                             let byte = try readRawByte()
                             if (byte >= 0) {
                                 return result;
@@ -658,20 +663,20 @@ public class CodedInputStream
         guard recursionDepth < recursionLimit else {
             throw ProtocolBuffersError.InvalidProtocolBuffer("Recursion Limit Exceeded")
         }
-        ++recursionDepth
+        recursionDepth += 1
         try builder.mergeFromCodedInputStream(self, extensionRegistry:extensionRegistry)
         try checkLastTagWas(WireFormat.EndGroup.makeTag(fieldNumber))
-        --recursionDepth
+        recursionDepth -= 1
     }
     public func readUnknownGroup(fieldNumber:Int32, builder:UnknownFieldSet.Builder) throws
     {
         guard recursionDepth < recursionLimit else {
             throw ProtocolBuffersError.InvalidProtocolBuffer("Recursion Limit Exceeded")
         }
-        ++recursionDepth
+        recursionDepth += 1
         try builder.mergeFromCodedInputStream(self)
         try checkLastTagWas(WireFormat.EndGroup.makeTag(fieldNumber))
-        --recursionDepth
+        recursionDepth -= 1
     }
 
     public func readMessage(builder:MessageBuilder, extensionRegistry:ExtensionRegistry) throws {
@@ -680,13 +685,12 @@ public class CodedInputStream
             throw ProtocolBuffersError.InvalidProtocolBuffer("Recursion Limit Exceeded")
         }
         let oldLimit =  try pushLimit(length)
-        ++recursionDepth
+        recursionDepth += 1
         try builder.mergeFromCodedInputStream(self, extensionRegistry:extensionRegistry)
         try checkLastTagWas(0)
-        --recursionDepth
+        recursionDepth -= 1
         popLimit(oldLimit)
     }
     
 }
-
 

--- a/Source/Google.Protobuf.Descriptor.proto.swift
+++ b/Source/Google.Protobuf.Descriptor.proto.swift
@@ -403,7 +403,7 @@ public extension Google.Protobuf {
           output += "\(indent) file[\(fileElementIndex)] {\n"
           output += try oneElementfile.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          fileElementIndex++
+          fileElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output
@@ -749,35 +749,35 @@ public extension Google.Protobuf {
       var dependencyElementIndex:Int = 0
       for oneValuedependency in dependency  {
           output += "\(indent) dependency[\(dependencyElementIndex)]: \(oneValuedependency)\n"
-          dependencyElementIndex++
+          dependencyElementIndex += 1
       }
       var messageTypeElementIndex:Int = 0
       for oneElementmessageType in messageType {
           output += "\(indent) messageType[\(messageTypeElementIndex)] {\n"
           output += try oneElementmessageType.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          messageTypeElementIndex++
+          messageTypeElementIndex += 1
       }
       var enumTypeElementIndex:Int = 0
       for oneElementenumType in enumType {
           output += "\(indent) enumType[\(enumTypeElementIndex)] {\n"
           output += try oneElementenumType.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          enumTypeElementIndex++
+          enumTypeElementIndex += 1
       }
       var serviceElementIndex:Int = 0
       for oneElementservice in service {
           output += "\(indent) service[\(serviceElementIndex)] {\n"
           output += try oneElementservice.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          serviceElementIndex++
+          serviceElementIndex += 1
       }
       var extension_ElementIndex:Int = 0
       for oneElementextension_ in extension_ {
           output += "\(indent) extension_[\(extension_ElementIndex)] {\n"
           output += try oneElementextension_.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          extension_ElementIndex++
+          extension_ElementIndex += 1
       }
       if hasOptions {
         output += "\(indent) options {\n"
@@ -796,12 +796,12 @@ public extension Google.Protobuf {
       var publicDependencyElementIndex:Int = 0
       for oneValuepublicDependency in publicDependency  {
           output += "\(indent) publicDependency[\(publicDependencyElementIndex)]: \(oneValuepublicDependency)\n"
-          publicDependencyElementIndex++
+          publicDependencyElementIndex += 1
       }
       var weakDependencyElementIndex:Int = 0
       for oneValueweakDependency in weakDependency  {
           output += "\(indent) weakDependency[\(weakDependencyElementIndex)]: \(oneValueweakDependency)\n"
-          weakDependencyElementIndex++
+          weakDependencyElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output
@@ -1701,35 +1701,35 @@ public extension Google.Protobuf {
           output += "\(indent) field[\(fieldElementIndex)] {\n"
           output += try oneElementfield.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          fieldElementIndex++
+          fieldElementIndex += 1
       }
       var nestedTypeElementIndex:Int = 0
       for oneElementnestedType in nestedType {
           output += "\(indent) nestedType[\(nestedTypeElementIndex)] {\n"
           output += try oneElementnestedType.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          nestedTypeElementIndex++
+          nestedTypeElementIndex += 1
       }
       var enumTypeElementIndex:Int = 0
       for oneElementenumType in enumType {
           output += "\(indent) enumType[\(enumTypeElementIndex)] {\n"
           output += try oneElementenumType.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          enumTypeElementIndex++
+          enumTypeElementIndex += 1
       }
       var extensionRangeElementIndex:Int = 0
       for oneElementextensionRange in extensionRange {
           output += "\(indent) extensionRange[\(extensionRangeElementIndex)] {\n"
           output += try oneElementextensionRange.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          extensionRangeElementIndex++
+          extensionRangeElementIndex += 1
       }
       var extension_ElementIndex:Int = 0
       for oneElementextension_ in extension_ {
           output += "\(indent) extension_[\(extension_ElementIndex)] {\n"
           output += try oneElementextension_.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          extension_ElementIndex++
+          extension_ElementIndex += 1
       }
       if hasOptions {
         output += "\(indent) options {\n"
@@ -1743,7 +1743,7 @@ public extension Google.Protobuf {
           output += "\(indent) oneofDecl[\(oneofDeclElementIndex)] {\n"
           output += try oneElementoneofDecl.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          oneofDeclElementIndex++
+          oneofDeclElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output
@@ -3091,7 +3091,7 @@ public extension Google.Protobuf {
           output += "\(indent) value[\(valueElementIndex)] {\n"
           output += try oneElementvalue.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          valueElementIndex++
+          valueElementIndex += 1
       }
       if hasOptions {
         output += "\(indent) options {\n"
@@ -3762,7 +3762,7 @@ public extension Google.Protobuf {
           output += "\(indent) method[\(methodElementIndex)] {\n"
           output += try oneElementmethod.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          methodElementIndex++
+          methodElementIndex += 1
       }
       if hasOptions {
         output += "\(indent) options {\n"
@@ -4652,7 +4652,7 @@ public extension Google.Protobuf {
           output += "\(indent) uninterpretedOption[\(uninterpretedOptionElementIndex)] {\n"
           output += try oneElementuninterpretedOption.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          uninterpretedOptionElementIndex++
+          uninterpretedOptionElementIndex += 1
       }
       output += try getExtensionDescription(Int32(1000), endExclusive:Int32(536870912), indent:indent)
       output += unknownFields.getDescription(indent)
@@ -5280,7 +5280,7 @@ public extension Google.Protobuf {
           output += "\(indent) uninterpretedOption[\(uninterpretedOptionElementIndex)] {\n"
           output += try oneElementuninterpretedOption.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          uninterpretedOptionElementIndex++
+          uninterpretedOptionElementIndex += 1
       }
       output += try getExtensionDescription(Int32(1000), endExclusive:Int32(536870912), indent:indent)
       output += unknownFields.getDescription(indent)
@@ -5719,7 +5719,7 @@ public extension Google.Protobuf {
           output += "\(indent) uninterpretedOption[\(uninterpretedOptionElementIndex)] {\n"
           output += try oneElementuninterpretedOption.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          uninterpretedOptionElementIndex++
+          uninterpretedOptionElementIndex += 1
       }
       output += try getExtensionDescription(Int32(1000), endExclusive:Int32(536870912), indent:indent)
       output += unknownFields.getDescription(indent)
@@ -6159,7 +6159,7 @@ public extension Google.Protobuf {
           output += "\(indent) uninterpretedOption[\(uninterpretedOptionElementIndex)] {\n"
           output += try oneElementuninterpretedOption.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          uninterpretedOptionElementIndex++
+          uninterpretedOptionElementIndex += 1
       }
       output += try getExtensionDescription(Int32(1000), endExclusive:Int32(536870912), indent:indent)
       output += unknownFields.getDescription(indent)
@@ -6452,7 +6452,7 @@ public extension Google.Protobuf {
           output += "\(indent) uninterpretedOption[\(uninterpretedOptionElementIndex)] {\n"
           output += try oneElementuninterpretedOption.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          uninterpretedOptionElementIndex++
+          uninterpretedOptionElementIndex += 1
       }
       output += try getExtensionDescription(Int32(1000), endExclusive:Int32(536870912), indent:indent)
       output += unknownFields.getDescription(indent)
@@ -6713,7 +6713,7 @@ public extension Google.Protobuf {
           output += "\(indent) uninterpretedOption[\(uninterpretedOptionElementIndex)] {\n"
           output += try oneElementuninterpretedOption.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          uninterpretedOptionElementIndex++
+          uninterpretedOptionElementIndex += 1
       }
       output += try getExtensionDescription(Int32(1000), endExclusive:Int32(536870912), indent:indent)
       output += unknownFields.getDescription(indent)
@@ -6974,7 +6974,7 @@ public extension Google.Protobuf {
           output += "\(indent) uninterpretedOption[\(uninterpretedOptionElementIndex)] {\n"
           output += try oneElementuninterpretedOption.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          uninterpretedOptionElementIndex++
+          uninterpretedOptionElementIndex += 1
       }
       output += try getExtensionDescription(Int32(1000), endExclusive:Int32(536870912), indent:indent)
       output += unknownFields.getDescription(indent)
@@ -7535,7 +7535,7 @@ public extension Google.Protobuf {
           output += "\(indent) name[\(nameElementIndex)] {\n"
           output += try oneElementname.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          nameElementIndex++
+          nameElementIndex += 1
       }
       if hasIdentifierValue {
         output += "\(indent) identifierValue: \(identifierValue) \n"
@@ -8047,12 +8047,12 @@ public extension Google.Protobuf {
           var pathElementIndex:Int = 0
           for oneValuepath in path  {
               output += "\(indent) path[\(pathElementIndex)]: \(oneValuepath)\n"
-              pathElementIndex++
+              pathElementIndex += 1
           }
           var spanElementIndex:Int = 0
           for oneValuespan in span  {
               output += "\(indent) span[\(spanElementIndex)]: \(oneValuespan)\n"
-              spanElementIndex++
+              spanElementIndex += 1
           }
           if hasLeadingComments {
             output += "\(indent) leadingComments: \(leadingComments) \n"
@@ -8351,7 +8351,7 @@ public extension Google.Protobuf {
           output += "\(indent) location[\(locationElementIndex)] {\n"
           output += try oneElementlocation.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          locationElementIndex++
+          locationElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output

--- a/Source/RingBuffer.swift
+++ b/Source/RingBuffer.swift
@@ -55,7 +55,8 @@ internal class RingBuffer
         }
         let pointer = UnsafeMutablePointer<UInt8>(buffer.mutableBytes)
         let bpointer = UnsafeMutableBufferPointer(start: pointer, count: buffer.length)
-        bpointer[Int(position++)] = aByte
+        bpointer[Int(position)] = aByte
+        position += 1
         return true
     }
     

--- a/plugin/ProtocolBuffers/ProtocolBuffersTests/CodedInputStreamTests.swift
+++ b/plugin/ProtocolBuffers/ProtocolBuffersTests/CodedInputStreamTests.swift
@@ -19,7 +19,7 @@ class CodedInputStreamTests: XCTestCase
         for index:UInt8 in from
         {
             bytesArray[i] = index
-            i++
+            i += 1
         }
         returnData.appendBytes(&bytesArray, length: bytesArray.count)
         return returnData
@@ -79,8 +79,8 @@ class CodedInputStreamTests: XCTestCase
         XCTAssertTrue(value == result4, "")
     
     // Try different block sizes.
-        for (var blockSize:Int32 = 1; blockSize <= 16; blockSize *= 2)
-        {
+        var blockSize: Int32 = 1
+        while blockSize <= 16 {
             if (shift == 0)
             {
                 let smallblock:SmallBlockInputStream = SmallBlockInputStream()
@@ -89,13 +89,13 @@ class CodedInputStreamTests: XCTestCase
                 let result2 = try inputs.readRawVarint32()
                 XCTAssertTrue(Int32(value) == result2, "")
             }
-        
+            
             let smallblock2:SmallBlockInputStream = SmallBlockInputStream()
             smallblock2.setup(data: data, blocksSize: blockSize)
             let inputs2:CodedInputStream = CodedInputStream(inputStream:smallblock2)
             let varin64 = try inputs2.readRawVarint64()
             XCTAssertTrue(value == varin64, "")
-
+            blockSize *= 2
         }
     }
     
@@ -107,14 +107,15 @@ class CodedInputStreamTests: XCTestCase
         let input:CodedInputStream = CodedInputStream(data:data)
         let readRes = try input.readRawLittleEndian32()
         XCTAssertTrue(value == readRes, "")
-        for (var blockSize:Int32 = 1; blockSize <= 16; blockSize *= 2)
-        {
+        var blockSize: Int32 = 1
+        while blockSize <= 16 {
             let smallblock:SmallBlockInputStream = SmallBlockInputStream()
             smallblock.setup(data: data, blocksSize: blockSize)
             
             let input2:CodedInputStream = CodedInputStream(inputStream:smallblock)
             let readRes2 = try input2.readRawLittleEndian32()
             XCTAssertTrue(value == readRes2, "")
+            blockSize *= 2
         }
     }
     
@@ -127,8 +128,8 @@ class CodedInputStreamTests: XCTestCase
         let input:CodedInputStream = CodedInputStream(data:data)
         let inputValue = try input.readRawLittleEndian64()
         XCTAssertTrue(value == inputValue, "")
-        for (var blockSize:Int32 = 1; blockSize <= 16; blockSize *= 2)
-        {
+        var blockSize: Int32 = 1
+        while blockSize <= 16 {
             let smallblock:SmallBlockInputStream = SmallBlockInputStream()
             smallblock.setup(data: data, blocksSize: blockSize)
             
@@ -136,6 +137,8 @@ class CodedInputStreamTests: XCTestCase
             
             let input2Value = try input2.readRawLittleEndian64()
             XCTAssertTrue(value == input2Value, "")
+            
+            blockSize *= 2
         }
     }
     
@@ -289,11 +292,14 @@ class CodedInputStreamTests: XCTestCase
             TestUtilities.assertAllFieldsSet(message3)
             XCTAssertTrue(message3 == message2, "")
             
-            for (var blockSize:Int32 = 1; blockSize < 256; blockSize *= 2) {
+            var blockSize: Int32 = 1
+            while blockSize < 256 {
                 let smallblock:SmallBlockInputStream = SmallBlockInputStream()
                 smallblock.setup(data: rawBytes, blocksSize: blockSize)
                 message2 = try ProtobufUnittest.TestAllTypes.parseFromInputStream(smallblock)
                 TestUtilities.assertAllFieldsSet(message2)
+                
+                blockSize *= 2
             }
         }
         catch
@@ -336,7 +342,7 @@ class CodedInputStreamTests: XCTestCase
         do {
             // Allocate and initialize a 1MB blob.
             let blob = NSMutableData(length:1 << 20)!
-            for (var i:Int = 0; i < blob.length; i++) {
+            for i in 0 ..< blob.length {
                 let pointer = UnsafeMutablePointer<UInt8>(blob.mutableBytes)
                 let bpointer = UnsafeMutableBufferPointer(start: pointer, count: blob.length)
                 bpointer[i] = UInt8(1)

--- a/plugin/ProtocolBuffers/ProtocolBuffersTests/CodedOuputStreamTests.swift
+++ b/plugin/ProtocolBuffers/ProtocolBuffersTests/CodedOuputStreamTests.swift
@@ -25,7 +25,7 @@ internal class CodedOuputStreamTests: XCTestCase
         for index:UInt8 in from
         {
             bytesArray[i] = index
-            i++
+            i += 1
         }
         returnData.appendBytes(&bytesArray, length: bytesArray.count)
         return returnData
@@ -42,16 +42,18 @@ internal class CodedOuputStreamTests: XCTestCase
         
         XCTAssertTrue(data.isEqualToData(actual), "Test32")
     
-        for var blockSize:Int32 = 1; blockSize <= 16; blockSize *= 2 {
-            
+        var blockSize:Int32 = 1
+        while blockSize <= 16 {
             let rawOutput:NSOutputStream = openMemoryStream()
             let output:CodedOutputStream = CodedOutputStream(output: rawOutput, bufferSize: blockSize)
             
             try output.writeRawLittleEndian32(value)
             try output.flush()
-    
+            
             let actual:NSData = rawOutput.propertyForKey(NSStreamDataWrittenToMemoryStreamKey) as! NSData
             XCTAssertTrue(data.isEqualToData(actual), "Test32")
+            
+            blockSize *= 2
         }
     }
     
@@ -65,8 +67,8 @@ internal class CodedOuputStreamTests: XCTestCase
 
         XCTAssertTrue(data.isEqualToData(actual), "Test64")
         
-        for var blockSize:Int32 = 1; blockSize <= 16; blockSize *= 2 {
-            
+        var blockSize:Int32 = 1
+        while blockSize <= 16 {
             let rawOutput:NSOutputStream = openMemoryStream()
             let output:CodedOutputStream = CodedOutputStream(output: rawOutput, bufferSize: blockSize)
             
@@ -76,6 +78,8 @@ internal class CodedOuputStreamTests: XCTestCase
             let actual:NSData = rawOutput.propertyForKey(NSStreamDataWrittenToMemoryStreamKey) as! NSData
             
             XCTAssertTrue(data.isEqualToData(actual),"Test64")
+
+            blockSize *= 2
         }
     }
     
@@ -106,30 +110,31 @@ internal class CodedOuputStreamTests: XCTestCase
     
     
         XCTAssertTrue(Int32(data.length) == value.computeRawVarint64Size(), "")
-    
-        for var blockSize:Int = 1; blockSize <= 16; blockSize *= 2
-        {
-    
+
+        var blockSize:Int32 = 1
+        while blockSize <= 16 {
             if (WireFormat.logicalRightShift64(value:value, spaces: 31) == 0)
             {
                 let rawOutput3:NSOutputStream = openMemoryStream()
                 let output3:CodedOutputStream = CodedOutputStream(output: rawOutput3, bufferSize: Int32(blockSize))
-    
+                
                 try output3.writeRawVarint32(Int32(value))
                 try output3.flush()
-    
+                
                 let actual3:NSData = rawOutput3.propertyForKey(NSStreamDataWrittenToMemoryStreamKey) as! NSData
                 XCTAssertTrue(data.isEqualToData(actual3), "")
             }
-    
-
+            
+            
             let rawOutput4:NSOutputStream = openMemoryStream()
             let output4:CodedOutputStream = CodedOutputStream(output: rawOutput4, bufferSize: Int32(blockSize))
             try output4.writeRawVarint64(value)
             try output4.flush()
-    
+            
             let actual4:NSData = rawOutput4.propertyForKey(NSStreamDataWrittenToMemoryStreamKey) as! NSData
             XCTAssertTrue(data.isEqualToData(actual4), "")
+
+            blockSize *= 2
         }
     }
     
@@ -321,13 +326,15 @@ internal class CodedOuputStreamTests: XCTestCase
             XCTAssertTrue(rawBytes == goldenData, "")
         
         // Try different block sizes.
-            for (var blockSize:Int = 1; blockSize < 256; blockSize *= 2) {
+            var blockSize = 1
+            while blockSize < 256 {
                 let rawOutput = openMemoryStream()
                 let output:CodedOutputStream = CodedOutputStream(output:rawOutput, bufferSize:Int32(blockSize))
                 try message.writeToCodedOutputStream(output)
                 try output.flush()
                 let actual = rawOutput.propertyForKey(NSStreamDataWrittenToMemoryStreamKey) as! NSData
                 XCTAssertTrue(rawBytes == actual, "")
+                blockSize *= 2
             }
         }
         catch

--- a/plugin/ProtocolBuffers/ProtocolBuffersTests/Performance.proto.swift
+++ b/plugin/ProtocolBuffers/ProtocolBuffersTests/Performance.proto.swift
@@ -658,7 +658,7 @@ final public class PBPerfomanceBatch : GeneratedMessage, GeneratedMessageProtoco
         output += "\(indent) batch[\(batchElementIndex)] {\n"
         output += try oneElementbatch.getDescription("\(indent)  ")
         output += "\(indent)}\n"
-        batchElementIndex++
+        batchElementIndex += 1
     }
     output += unknownFields.getDescription(indent)
     return output

--- a/plugin/ProtocolBuffers/ProtocolBuffersTests/UnknowFieldsTests.swift
+++ b/plugin/ProtocolBuffers/ProtocolBuffersTests/UnknowFieldsTests.swift
@@ -52,9 +52,9 @@ class UnknowFieldsTests: XCTestCase {
     
     func getBizarroData() throws -> NSData {
         let bizarroFields = UnknownFieldSet.Builder()
-        var letintField = Field()
+        let letintField = Field()
         letintField += Int32(1)
-        var fixed32Field = Field()
+        let fixed32Field = Field()
         fixed32Field += UInt32(2)
     
         for key in unknownFields.fields.keys {
@@ -89,38 +89,38 @@ class UnknowFieldsTests: XCTestCase {
         
         do {
             let set1Builder = UnknownFieldSet.Builder()
-            var field1 = Field()
+            let field1 = Field()
             field1 += Int32(2)
             try set1Builder.addField(field1, number: 2)
-            var field2 = Field()
+            let field2 = Field()
             field2 += Int32(4)
             try set1Builder.addField(field2, number: 3)
             let set1 = try set1Builder.build()
             
             let set2Builder = UnknownFieldSet.Builder()
-            var field3 = Field()
+            let field3 = Field()
             field3 += Int32(1)
             try set2Builder.addField(field3, number: 1)
-            var field4 = Field()
+            let field4 = Field()
             field4 += Int32(3)
             try set2Builder.addField(field4, number: 3)
             let set2 = try set2Builder.build()
             
             
             let set3Builder = UnknownFieldSet.Builder()
-            var field5 = Field()
+            let field5 = Field()
             field5 += Int32(1)
             try set3Builder.addField(field5, number: 1)
-            var field6 = Field()
+            let field6 = Field()
             field6 += Int32(4)
             try set3Builder.addField(field6, number: 3)
             let set3 = try set3Builder.build()
             
             let set4Builder = UnknownFieldSet.Builder()
-            var field7 = Field()
+            let field7 = Field()
             field7 += Int32(2)
             try set4Builder.addField(field7, number: 2)
-            var field8 = Field()
+            let field8 = Field()
             field8 += Int32(3)
             try set4Builder.addField(field8, number: 3)
             let set4 = try set4Builder.build()
@@ -187,7 +187,7 @@ class UnknowFieldsTests: XCTestCase {
     func testParseKnownAndUnknown() {
         do {
             // Test mixing known and unknown fields when parsing.
-            var field = Field()
+            let field = Field()
             field += Int32(654321)
             let fields = try UnknownFieldSet.builderWithUnknownFields(unknownFields).addField(field, number:123456).build()
             let data = try fields.data()
@@ -255,7 +255,7 @@ class UnknowFieldsTests: XCTestCase {
     
     func testLargeletint() {
         do {
-            var field = Field()
+            let field = Field()
             field += Int64(Int64.max)
             let data = try UnknownFieldSet.Builder().addField(field, number:1).build().data()
             let parsed = try UnknownFieldSet.parseFromData(data)

--- a/plugin/ProtocolBuffers/ProtocolBuffersTests/pbTests/ProtobufUnittest.Unittest.proto.swift
+++ b/plugin/ProtocolBuffers/ProtocolBuffersTests/pbTests/ProtobufUnittest.Unittest.proto.swift
@@ -3848,137 +3848,137 @@ internal extension ProtobufUnittest {
       var repeatedInt32ElementIndex:Int = 0
       for oneValuerepeatedInt32 in repeatedInt32  {
           output += "\(indent) repeatedInt32[\(repeatedInt32ElementIndex)]: \(oneValuerepeatedInt32)\n"
-          repeatedInt32ElementIndex++
+          repeatedInt32ElementIndex += 1
       }
       var repeatedInt64ElementIndex:Int = 0
       for oneValuerepeatedInt64 in repeatedInt64  {
           output += "\(indent) repeatedInt64[\(repeatedInt64ElementIndex)]: \(oneValuerepeatedInt64)\n"
-          repeatedInt64ElementIndex++
+          repeatedInt64ElementIndex += 1
       }
       var repeatedUint32ElementIndex:Int = 0
       for oneValuerepeatedUint32 in repeatedUint32  {
           output += "\(indent) repeatedUint32[\(repeatedUint32ElementIndex)]: \(oneValuerepeatedUint32)\n"
-          repeatedUint32ElementIndex++
+          repeatedUint32ElementIndex += 1
       }
       var repeatedUint64ElementIndex:Int = 0
       for oneValuerepeatedUint64 in repeatedUint64  {
           output += "\(indent) repeatedUint64[\(repeatedUint64ElementIndex)]: \(oneValuerepeatedUint64)\n"
-          repeatedUint64ElementIndex++
+          repeatedUint64ElementIndex += 1
       }
       var repeatedSint32ElementIndex:Int = 0
       for oneValuerepeatedSint32 in repeatedSint32  {
           output += "\(indent) repeatedSint32[\(repeatedSint32ElementIndex)]: \(oneValuerepeatedSint32)\n"
-          repeatedSint32ElementIndex++
+          repeatedSint32ElementIndex += 1
       }
       var repeatedSint64ElementIndex:Int = 0
       for oneValuerepeatedSint64 in repeatedSint64  {
           output += "\(indent) repeatedSint64[\(repeatedSint64ElementIndex)]: \(oneValuerepeatedSint64)\n"
-          repeatedSint64ElementIndex++
+          repeatedSint64ElementIndex += 1
       }
       var repeatedFixed32ElementIndex:Int = 0
       for oneValuerepeatedFixed32 in repeatedFixed32  {
           output += "\(indent) repeatedFixed32[\(repeatedFixed32ElementIndex)]: \(oneValuerepeatedFixed32)\n"
-          repeatedFixed32ElementIndex++
+          repeatedFixed32ElementIndex += 1
       }
       var repeatedFixed64ElementIndex:Int = 0
       for oneValuerepeatedFixed64 in repeatedFixed64  {
           output += "\(indent) repeatedFixed64[\(repeatedFixed64ElementIndex)]: \(oneValuerepeatedFixed64)\n"
-          repeatedFixed64ElementIndex++
+          repeatedFixed64ElementIndex += 1
       }
       var repeatedSfixed32ElementIndex:Int = 0
       for oneValuerepeatedSfixed32 in repeatedSfixed32  {
           output += "\(indent) repeatedSfixed32[\(repeatedSfixed32ElementIndex)]: \(oneValuerepeatedSfixed32)\n"
-          repeatedSfixed32ElementIndex++
+          repeatedSfixed32ElementIndex += 1
       }
       var repeatedSfixed64ElementIndex:Int = 0
       for oneValuerepeatedSfixed64 in repeatedSfixed64  {
           output += "\(indent) repeatedSfixed64[\(repeatedSfixed64ElementIndex)]: \(oneValuerepeatedSfixed64)\n"
-          repeatedSfixed64ElementIndex++
+          repeatedSfixed64ElementIndex += 1
       }
       var repeatedFloatElementIndex:Int = 0
       for oneValuerepeatedFloat in repeatedFloat  {
           output += "\(indent) repeatedFloat[\(repeatedFloatElementIndex)]: \(oneValuerepeatedFloat)\n"
-          repeatedFloatElementIndex++
+          repeatedFloatElementIndex += 1
       }
       var repeatedDoubleElementIndex:Int = 0
       for oneValuerepeatedDouble in repeatedDouble  {
           output += "\(indent) repeatedDouble[\(repeatedDoubleElementIndex)]: \(oneValuerepeatedDouble)\n"
-          repeatedDoubleElementIndex++
+          repeatedDoubleElementIndex += 1
       }
       var repeatedBoolElementIndex:Int = 0
       for oneValuerepeatedBool in repeatedBool  {
           output += "\(indent) repeatedBool[\(repeatedBoolElementIndex)]: \(oneValuerepeatedBool)\n"
-          repeatedBoolElementIndex++
+          repeatedBoolElementIndex += 1
       }
       var repeatedStringElementIndex:Int = 0
       for oneValuerepeatedString in repeatedString  {
           output += "\(indent) repeatedString[\(repeatedStringElementIndex)]: \(oneValuerepeatedString)\n"
-          repeatedStringElementIndex++
+          repeatedStringElementIndex += 1
       }
       var repeatedBytesElementIndex:Int = 0
       for oneValuerepeatedBytes in repeatedBytes  {
           output += "\(indent) repeatedBytes[\(repeatedBytesElementIndex)]: \(oneValuerepeatedBytes)\n"
-          repeatedBytesElementIndex++
+          repeatedBytesElementIndex += 1
       }
       var repeatedGroupElementIndex:Int = 0
       for oneElementrepeatedGroup in repeatedGroup {
           output += "\(indent) repeatedGroup[\(repeatedGroupElementIndex)] {\n"
           output += try oneElementrepeatedGroup.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedGroupElementIndex++
+          repeatedGroupElementIndex += 1
       }
       var repeatedNestedMessageElementIndex:Int = 0
       for oneElementrepeatedNestedMessage in repeatedNestedMessage {
           output += "\(indent) repeatedNestedMessage[\(repeatedNestedMessageElementIndex)] {\n"
           output += try oneElementrepeatedNestedMessage.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedNestedMessageElementIndex++
+          repeatedNestedMessageElementIndex += 1
       }
       var repeatedForeignMessageElementIndex:Int = 0
       for oneElementrepeatedForeignMessage in repeatedForeignMessage {
           output += "\(indent) repeatedForeignMessage[\(repeatedForeignMessageElementIndex)] {\n"
           output += try oneElementrepeatedForeignMessage.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedForeignMessageElementIndex++
+          repeatedForeignMessageElementIndex += 1
       }
       var repeatedImportMessageElementIndex:Int = 0
       for oneElementrepeatedImportMessage in repeatedImportMessage {
           output += "\(indent) repeatedImportMessage[\(repeatedImportMessageElementIndex)] {\n"
           output += try oneElementrepeatedImportMessage.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedImportMessageElementIndex++
+          repeatedImportMessageElementIndex += 1
       }
       var repeatedNestedEnumElementIndex:Int = 0
       for oneValueOfrepeatedNestedEnum in repeatedNestedEnum {
           output += "\(indent) repeatedNestedEnum[\(repeatedNestedEnumElementIndex)]: \(oneValueOfrepeatedNestedEnum.rawValue)\n"
-          repeatedNestedEnumElementIndex++
+          repeatedNestedEnumElementIndex += 1
       }
       var repeatedForeignEnumElementIndex:Int = 0
       for oneValueOfrepeatedForeignEnum in repeatedForeignEnum {
           output += "\(indent) repeatedForeignEnum[\(repeatedForeignEnumElementIndex)]: \(oneValueOfrepeatedForeignEnum.rawValue)\n"
-          repeatedForeignEnumElementIndex++
+          repeatedForeignEnumElementIndex += 1
       }
       var repeatedImportEnumElementIndex:Int = 0
       for oneValueOfrepeatedImportEnum in repeatedImportEnum {
           output += "\(indent) repeatedImportEnum[\(repeatedImportEnumElementIndex)]: \(oneValueOfrepeatedImportEnum.rawValue)\n"
-          repeatedImportEnumElementIndex++
+          repeatedImportEnumElementIndex += 1
       }
       var repeatedStringPieceElementIndex:Int = 0
       for oneValuerepeatedStringPiece in repeatedStringPiece  {
           output += "\(indent) repeatedStringPiece[\(repeatedStringPieceElementIndex)]: \(oneValuerepeatedStringPiece)\n"
-          repeatedStringPieceElementIndex++
+          repeatedStringPieceElementIndex += 1
       }
       var repeatedCordElementIndex:Int = 0
       for oneValuerepeatedCord in repeatedCord  {
           output += "\(indent) repeatedCord[\(repeatedCordElementIndex)]: \(oneValuerepeatedCord)\n"
-          repeatedCordElementIndex++
+          repeatedCordElementIndex += 1
       }
       var repeatedLazyMessageElementIndex:Int = 0
       for oneElementrepeatedLazyMessage in repeatedLazyMessage {
           output += "\(indent) repeatedLazyMessage[\(repeatedLazyMessageElementIndex)] {\n"
           output += try oneElementrepeatedLazyMessage.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedLazyMessageElementIndex++
+          repeatedLazyMessageElementIndex += 1
       }
       if hasDefaultInt32 {
         output += "\(indent) defaultInt32: \(defaultInt32) \n"
@@ -9855,7 +9855,7 @@ internal extension ProtobufUnittest {
           output += "\(indent) repeatedMessage[\(repeatedMessageElementIndex)] {\n"
           output += try oneElementrepeatedMessage.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedMessageElementIndex++
+          repeatedMessageElementIndex += 1
       }
       if hasDummy {
         output += "\(indent) dummy: \(dummy) \n"
@@ -13198,14 +13198,14 @@ internal extension ProtobufUnittest {
           var nestedmessageRepeatedInt32ElementIndex:Int = 0
           for oneValuenestedmessageRepeatedInt32 in nestedmessageRepeatedInt32  {
               output += "\(indent) nestedmessageRepeatedInt32[\(nestedmessageRepeatedInt32ElementIndex)]: \(oneValuenestedmessageRepeatedInt32)\n"
-              nestedmessageRepeatedInt32ElementIndex++
+              nestedmessageRepeatedInt32ElementIndex += 1
           }
           var nestedmessageRepeatedForeignmessageElementIndex:Int = 0
           for oneElementnestedmessageRepeatedForeignmessage in nestedmessageRepeatedForeignmessage {
               output += "\(indent) nestedmessageRepeatedForeignmessage[\(nestedmessageRepeatedForeignmessageElementIndex)] {\n"
               output += try oneElementnestedmessageRepeatedForeignmessage.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              nestedmessageRepeatedForeignmessageElementIndex++
+              nestedmessageRepeatedForeignmessageElementIndex += 1
           }
           output += unknownFields.getDescription(indent)
           return output
@@ -13799,34 +13799,34 @@ internal extension ProtobufUnittest {
       var repeatedPrimitiveFieldElementIndex:Int = 0
       for oneValuerepeatedPrimitiveField in repeatedPrimitiveField  {
           output += "\(indent) repeatedPrimitiveField[\(repeatedPrimitiveFieldElementIndex)]: \(oneValuerepeatedPrimitiveField)\n"
-          repeatedPrimitiveFieldElementIndex++
+          repeatedPrimitiveFieldElementIndex += 1
       }
       var repeatedStringFieldElementIndex:Int = 0
       for oneValuerepeatedStringField in repeatedStringField  {
           output += "\(indent) repeatedStringField[\(repeatedStringFieldElementIndex)]: \(oneValuerepeatedStringField)\n"
-          repeatedStringFieldElementIndex++
+          repeatedStringFieldElementIndex += 1
       }
       var repeatedEnumFieldElementIndex:Int = 0
       for oneValueOfrepeatedEnumField in repeatedEnumField {
           output += "\(indent) repeatedEnumField[\(repeatedEnumFieldElementIndex)]: \(oneValueOfrepeatedEnumField.rawValue)\n"
-          repeatedEnumFieldElementIndex++
+          repeatedEnumFieldElementIndex += 1
       }
       var repeatedMessageFieldElementIndex:Int = 0
       for oneElementrepeatedMessageField in repeatedMessageField {
           output += "\(indent) repeatedMessageField[\(repeatedMessageFieldElementIndex)] {\n"
           output += try oneElementrepeatedMessageField.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedMessageFieldElementIndex++
+          repeatedMessageFieldElementIndex += 1
       }
       var repeatedStringPieceFieldElementIndex:Int = 0
       for oneValuerepeatedStringPieceField in repeatedStringPieceField  {
           output += "\(indent) repeatedStringPieceField[\(repeatedStringPieceFieldElementIndex)]: \(oneValuerepeatedStringPieceField)\n"
-          repeatedStringPieceFieldElementIndex++
+          repeatedStringPieceFieldElementIndex += 1
       }
       var repeatedCordFieldElementIndex:Int = 0
       for oneValuerepeatedCordField in repeatedCordField  {
           output += "\(indent) repeatedCordField[\(repeatedCordFieldElementIndex)]: \(oneValuerepeatedCordField)\n"
-          repeatedCordFieldElementIndex++
+          repeatedCordFieldElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output
@@ -16440,7 +16440,7 @@ internal extension ProtobufUnittest {
       var dataElementIndex:Int = 0
       for oneValuedata in data  {
           output += "\(indent) data[\(dataElementIndex)]: \(oneValuedata)\n"
-          dataElementIndex++
+          dataElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output
@@ -16834,7 +16834,7 @@ internal extension ProtobufUnittest {
       var dataElementIndex:Int = 0
       for oneValuedata in data  {
           output += "\(indent) data[\(dataElementIndex)]: \(oneValuedata)\n"
-          dataElementIndex++
+          dataElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output
@@ -19724,7 +19724,7 @@ internal extension ProtobufUnittest {
           var corgeIntElementIndex:Int = 0
           for oneValuecorgeInt in corgeInt  {
               output += "\(indent) corgeInt[\(corgeIntElementIndex)]: \(oneValuecorgeInt)\n"
-              corgeIntElementIndex++
+              corgeIntElementIndex += 1
           }
           output += unknownFields.getDescription(indent)
           return output
@@ -22287,72 +22287,72 @@ internal extension ProtobufUnittest {
       var packedInt32ElementIndex:Int = 0
       for oneValuepackedInt32 in packedInt32  {
           output += "\(indent) packedInt32[\(packedInt32ElementIndex)]: \(oneValuepackedInt32)\n"
-          packedInt32ElementIndex++
+          packedInt32ElementIndex += 1
       }
       var packedInt64ElementIndex:Int = 0
       for oneValuepackedInt64 in packedInt64  {
           output += "\(indent) packedInt64[\(packedInt64ElementIndex)]: \(oneValuepackedInt64)\n"
-          packedInt64ElementIndex++
+          packedInt64ElementIndex += 1
       }
       var packedUint32ElementIndex:Int = 0
       for oneValuepackedUint32 in packedUint32  {
           output += "\(indent) packedUint32[\(packedUint32ElementIndex)]: \(oneValuepackedUint32)\n"
-          packedUint32ElementIndex++
+          packedUint32ElementIndex += 1
       }
       var packedUint64ElementIndex:Int = 0
       for oneValuepackedUint64 in packedUint64  {
           output += "\(indent) packedUint64[\(packedUint64ElementIndex)]: \(oneValuepackedUint64)\n"
-          packedUint64ElementIndex++
+          packedUint64ElementIndex += 1
       }
       var packedSint32ElementIndex:Int = 0
       for oneValuepackedSint32 in packedSint32  {
           output += "\(indent) packedSint32[\(packedSint32ElementIndex)]: \(oneValuepackedSint32)\n"
-          packedSint32ElementIndex++
+          packedSint32ElementIndex += 1
       }
       var packedSint64ElementIndex:Int = 0
       for oneValuepackedSint64 in packedSint64  {
           output += "\(indent) packedSint64[\(packedSint64ElementIndex)]: \(oneValuepackedSint64)\n"
-          packedSint64ElementIndex++
+          packedSint64ElementIndex += 1
       }
       var packedFixed32ElementIndex:Int = 0
       for oneValuepackedFixed32 in packedFixed32  {
           output += "\(indent) packedFixed32[\(packedFixed32ElementIndex)]: \(oneValuepackedFixed32)\n"
-          packedFixed32ElementIndex++
+          packedFixed32ElementIndex += 1
       }
       var packedFixed64ElementIndex:Int = 0
       for oneValuepackedFixed64 in packedFixed64  {
           output += "\(indent) packedFixed64[\(packedFixed64ElementIndex)]: \(oneValuepackedFixed64)\n"
-          packedFixed64ElementIndex++
+          packedFixed64ElementIndex += 1
       }
       var packedSfixed32ElementIndex:Int = 0
       for oneValuepackedSfixed32 in packedSfixed32  {
           output += "\(indent) packedSfixed32[\(packedSfixed32ElementIndex)]: \(oneValuepackedSfixed32)\n"
-          packedSfixed32ElementIndex++
+          packedSfixed32ElementIndex += 1
       }
       var packedSfixed64ElementIndex:Int = 0
       for oneValuepackedSfixed64 in packedSfixed64  {
           output += "\(indent) packedSfixed64[\(packedSfixed64ElementIndex)]: \(oneValuepackedSfixed64)\n"
-          packedSfixed64ElementIndex++
+          packedSfixed64ElementIndex += 1
       }
       var packedFloatElementIndex:Int = 0
       for oneValuepackedFloat in packedFloat  {
           output += "\(indent) packedFloat[\(packedFloatElementIndex)]: \(oneValuepackedFloat)\n"
-          packedFloatElementIndex++
+          packedFloatElementIndex += 1
       }
       var packedDoubleElementIndex:Int = 0
       for oneValuepackedDouble in packedDouble  {
           output += "\(indent) packedDouble[\(packedDoubleElementIndex)]: \(oneValuepackedDouble)\n"
-          packedDoubleElementIndex++
+          packedDoubleElementIndex += 1
       }
       var packedBoolElementIndex:Int = 0
       for oneValuepackedBool in packedBool  {
           output += "\(indent) packedBool[\(packedBoolElementIndex)]: \(oneValuepackedBool)\n"
-          packedBoolElementIndex++
+          packedBoolElementIndex += 1
       }
       var packedEnumElementIndex:Int = 0
       for oneValueOfpackedEnum in packedEnum {
           output += "\(indent) packedEnum[\(packedEnumElementIndex)]: \(oneValueOfpackedEnum.rawValue)\n"
-          packedEnumElementIndex++
+          packedEnumElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output
@@ -23091,72 +23091,72 @@ internal extension ProtobufUnittest {
       var unpackedInt32ElementIndex:Int = 0
       for oneValueunpackedInt32 in unpackedInt32  {
           output += "\(indent) unpackedInt32[\(unpackedInt32ElementIndex)]: \(oneValueunpackedInt32)\n"
-          unpackedInt32ElementIndex++
+          unpackedInt32ElementIndex += 1
       }
       var unpackedInt64ElementIndex:Int = 0
       for oneValueunpackedInt64 in unpackedInt64  {
           output += "\(indent) unpackedInt64[\(unpackedInt64ElementIndex)]: \(oneValueunpackedInt64)\n"
-          unpackedInt64ElementIndex++
+          unpackedInt64ElementIndex += 1
       }
       var unpackedUint32ElementIndex:Int = 0
       for oneValueunpackedUint32 in unpackedUint32  {
           output += "\(indent) unpackedUint32[\(unpackedUint32ElementIndex)]: \(oneValueunpackedUint32)\n"
-          unpackedUint32ElementIndex++
+          unpackedUint32ElementIndex += 1
       }
       var unpackedUint64ElementIndex:Int = 0
       for oneValueunpackedUint64 in unpackedUint64  {
           output += "\(indent) unpackedUint64[\(unpackedUint64ElementIndex)]: \(oneValueunpackedUint64)\n"
-          unpackedUint64ElementIndex++
+          unpackedUint64ElementIndex += 1
       }
       var unpackedSint32ElementIndex:Int = 0
       for oneValueunpackedSint32 in unpackedSint32  {
           output += "\(indent) unpackedSint32[\(unpackedSint32ElementIndex)]: \(oneValueunpackedSint32)\n"
-          unpackedSint32ElementIndex++
+          unpackedSint32ElementIndex += 1
       }
       var unpackedSint64ElementIndex:Int = 0
       for oneValueunpackedSint64 in unpackedSint64  {
           output += "\(indent) unpackedSint64[\(unpackedSint64ElementIndex)]: \(oneValueunpackedSint64)\n"
-          unpackedSint64ElementIndex++
+          unpackedSint64ElementIndex += 1
       }
       var unpackedFixed32ElementIndex:Int = 0
       for oneValueunpackedFixed32 in unpackedFixed32  {
           output += "\(indent) unpackedFixed32[\(unpackedFixed32ElementIndex)]: \(oneValueunpackedFixed32)\n"
-          unpackedFixed32ElementIndex++
+          unpackedFixed32ElementIndex += 1
       }
       var unpackedFixed64ElementIndex:Int = 0
       for oneValueunpackedFixed64 in unpackedFixed64  {
           output += "\(indent) unpackedFixed64[\(unpackedFixed64ElementIndex)]: \(oneValueunpackedFixed64)\n"
-          unpackedFixed64ElementIndex++
+          unpackedFixed64ElementIndex += 1
       }
       var unpackedSfixed32ElementIndex:Int = 0
       for oneValueunpackedSfixed32 in unpackedSfixed32  {
           output += "\(indent) unpackedSfixed32[\(unpackedSfixed32ElementIndex)]: \(oneValueunpackedSfixed32)\n"
-          unpackedSfixed32ElementIndex++
+          unpackedSfixed32ElementIndex += 1
       }
       var unpackedSfixed64ElementIndex:Int = 0
       for oneValueunpackedSfixed64 in unpackedSfixed64  {
           output += "\(indent) unpackedSfixed64[\(unpackedSfixed64ElementIndex)]: \(oneValueunpackedSfixed64)\n"
-          unpackedSfixed64ElementIndex++
+          unpackedSfixed64ElementIndex += 1
       }
       var unpackedFloatElementIndex:Int = 0
       for oneValueunpackedFloat in unpackedFloat  {
           output += "\(indent) unpackedFloat[\(unpackedFloatElementIndex)]: \(oneValueunpackedFloat)\n"
-          unpackedFloatElementIndex++
+          unpackedFloatElementIndex += 1
       }
       var unpackedDoubleElementIndex:Int = 0
       for oneValueunpackedDouble in unpackedDouble  {
           output += "\(indent) unpackedDouble[\(unpackedDoubleElementIndex)]: \(oneValueunpackedDouble)\n"
-          unpackedDoubleElementIndex++
+          unpackedDoubleElementIndex += 1
       }
       var unpackedBoolElementIndex:Int = 0
       for oneValueunpackedBool in unpackedBool  {
           output += "\(indent) unpackedBool[\(unpackedBoolElementIndex)]: \(oneValueunpackedBool)\n"
-          unpackedBoolElementIndex++
+          unpackedBoolElementIndex += 1
       }
       var unpackedEnumElementIndex:Int = 0
       for oneValueOfunpackedEnum in unpackedEnum {
           output += "\(indent) unpackedEnum[\(unpackedEnumElementIndex)]: \(oneValueOfunpackedEnum.rawValue)\n"
-          unpackedEnumElementIndex++
+          unpackedEnumElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output
@@ -24313,12 +24313,12 @@ internal extension ProtobufUnittest {
       var repeatedExtensionElementIndex:Int = 0
       for oneValuerepeatedExtension in repeatedExtension  {
           output += "\(indent) repeatedExtension[\(repeatedExtensionElementIndex)]: \(oneValuerepeatedExtension)\n"
-          repeatedExtensionElementIndex++
+          repeatedExtensionElementIndex += 1
       }
       var packedExtensionElementIndex:Int = 0
       for oneValuepackedExtension in packedExtension  {
           output += "\(indent) packedExtension[\(packedExtensionElementIndex)]: \(oneValuepackedExtension)\n"
-          packedExtensionElementIndex++
+          packedExtensionElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output
@@ -24844,32 +24844,32 @@ internal extension ProtobufUnittest {
       var repeatedFixed32ElementIndex:Int = 0
       for oneValuerepeatedFixed32 in repeatedFixed32  {
           output += "\(indent) repeatedFixed32[\(repeatedFixed32ElementIndex)]: \(oneValuerepeatedFixed32)\n"
-          repeatedFixed32ElementIndex++
+          repeatedFixed32ElementIndex += 1
       }
       var repeatedInt32ElementIndex:Int = 0
       for oneValuerepeatedInt32 in repeatedInt32  {
           output += "\(indent) repeatedInt32[\(repeatedInt32ElementIndex)]: \(oneValuerepeatedInt32)\n"
-          repeatedInt32ElementIndex++
+          repeatedInt32ElementIndex += 1
       }
       var repeatedFixed64ElementIndex:Int = 0
       for oneValuerepeatedFixed64 in repeatedFixed64  {
           output += "\(indent) repeatedFixed64[\(repeatedFixed64ElementIndex)]: \(oneValuerepeatedFixed64)\n"
-          repeatedFixed64ElementIndex++
+          repeatedFixed64ElementIndex += 1
       }
       var repeatedInt64ElementIndex:Int = 0
       for oneValuerepeatedInt64 in repeatedInt64  {
           output += "\(indent) repeatedInt64[\(repeatedInt64ElementIndex)]: \(oneValuerepeatedInt64)\n"
-          repeatedInt64ElementIndex++
+          repeatedInt64ElementIndex += 1
       }
       var repeatedFloatElementIndex:Int = 0
       for oneValuerepeatedFloat in repeatedFloat  {
           output += "\(indent) repeatedFloat[\(repeatedFloatElementIndex)]: \(oneValuerepeatedFloat)\n"
-          repeatedFloatElementIndex++
+          repeatedFloatElementIndex += 1
       }
       var repeatedUint64ElementIndex:Int = 0
       for oneValuerepeatedUint64 in repeatedUint64  {
           output += "\(indent) repeatedUint64[\(repeatedUint64ElementIndex)]: \(oneValuerepeatedUint64)\n"
-          repeatedUint64ElementIndex++
+          repeatedUint64ElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output
@@ -25729,49 +25729,49 @@ internal extension ProtobufUnittest {
               output += "\(indent) field1[\(field1ElementIndex)] {\n"
               output += try oneElementfield1.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              field1ElementIndex++
+              field1ElementIndex += 1
           }
           var field2ElementIndex:Int = 0
           for oneElementfield2 in field2 {
               output += "\(indent) field2[\(field2ElementIndex)] {\n"
               output += try oneElementfield2.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              field2ElementIndex++
+              field2ElementIndex += 1
           }
           var field3ElementIndex:Int = 0
           for oneElementfield3 in field3 {
               output += "\(indent) field3[\(field3ElementIndex)] {\n"
               output += try oneElementfield3.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              field3ElementIndex++
+              field3ElementIndex += 1
           }
           var group1ElementIndex:Int = 0
           for oneElementgroup1 in group1 {
               output += "\(indent) group1[\(group1ElementIndex)] {\n"
               output += try oneElementgroup1.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              group1ElementIndex++
+              group1ElementIndex += 1
           }
           var group2ElementIndex:Int = 0
           for oneElementgroup2 in group2 {
               output += "\(indent) group2[\(group2ElementIndex)] {\n"
               output += try oneElementgroup2.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              group2ElementIndex++
+              group2ElementIndex += 1
           }
           var ext1ElementIndex:Int = 0
           for oneElementext1 in ext1 {
               output += "\(indent) ext1[\(ext1ElementIndex)] {\n"
               output += try oneElementext1.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              ext1ElementIndex++
+              ext1ElementIndex += 1
           }
           var ext2ElementIndex:Int = 0
           for oneElementext2 in ext2 {
               output += "\(indent) ext2[\(ext2ElementIndex)] {\n"
               output += try oneElementext2.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              ext2ElementIndex++
+              ext2ElementIndex += 1
           }
           output += unknownFields.getDescription(indent)
           return output
@@ -26682,7 +26682,7 @@ internal extension ProtobufUnittest {
           output += "\(indent) repeatedAllTypes[\(repeatedAllTypesElementIndex)] {\n"
           output += try oneElementrepeatedAllTypes.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedAllTypesElementIndex++
+          repeatedAllTypesElementIndex += 1
       }
       if hasOptionalGroup {
         output += "\(indent) optionalGroup {\n"
@@ -26696,7 +26696,7 @@ internal extension ProtobufUnittest {
           output += "\(indent) repeatedGroup[\(repeatedGroupElementIndex)] {\n"
           output += try oneElementrepeatedGroup.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedGroupElementIndex++
+          repeatedGroupElementIndex += 1
       }
       output += try getExtensionDescription(Int32(1000), endExclusive:Int32(536870912), indent:indent)
       output += unknownFields.getDescription(indent)

--- a/plugin/ProtocolBuffers/ProtocolBuffersTests/pbTests/ProtobufUnittest.UnittestCustomOptions.proto.swift
+++ b/plugin/ProtocolBuffers/ProtocolBuffersTests/pbTests/ProtobufUnittest.UnittestCustomOptions.proto.swift
@@ -2818,7 +2818,7 @@ internal extension ProtobufUnittest {
       var foo4ElementIndex:Int = 0
       for oneValuefoo4 in foo4  {
           output += "\(indent) foo4[\(foo4ElementIndex)]: \(oneValuefoo4)\n"
-          foo4ElementIndex++
+          foo4ElementIndex += 1
       }
       output += try getExtensionDescription(Int32(100), endExclusive:Int32(536870912), indent:indent)
       output += unknownFields.getDescription(indent)
@@ -3373,7 +3373,7 @@ internal extension ProtobufUnittest {
           output += "\(indent) barney[\(barneyElementIndex)] {\n"
           output += try oneElementbarney.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          barneyElementIndex++
+          barneyElementIndex += 1
       }
       output += try getExtensionDescription(Int32(100), endExclusive:Int32(536870912), indent:indent)
       output += unknownFields.getDescription(indent)

--- a/plugin/ProtocolBuffers/ProtocolBuffersTests/pbTests/ProtobufUnittest.UnittestEmbedOptimizeFor.proto.swift
+++ b/plugin/ProtocolBuffers/ProtocolBuffersTests/pbTests/ProtobufUnittest.UnittestEmbedOptimizeFor.proto.swift
@@ -150,7 +150,7 @@ internal extension ProtobufUnittest {
           output += "\(indent) repeatedMessage[\(repeatedMessageElementIndex)] {\n"
           output += try oneElementrepeatedMessage.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedMessageElementIndex++
+          repeatedMessageElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output

--- a/plugin/ProtocolBuffers/ProtocolBuffersTests/pbTests/ProtobufUnittest.UnittestLite.proto.swift
+++ b/plugin/ProtocolBuffers/ProtocolBuffersTests/pbTests/ProtobufUnittest.UnittestLite.proto.swift
@@ -2975,137 +2975,137 @@ internal extension ProtobufUnittest {
       var repeatedInt32ElementIndex:Int = 0
       for oneValuerepeatedInt32 in repeatedInt32  {
           output += "\(indent) repeatedInt32[\(repeatedInt32ElementIndex)]: \(oneValuerepeatedInt32)\n"
-          repeatedInt32ElementIndex++
+          repeatedInt32ElementIndex += 1
       }
       var repeatedInt64ElementIndex:Int = 0
       for oneValuerepeatedInt64 in repeatedInt64  {
           output += "\(indent) repeatedInt64[\(repeatedInt64ElementIndex)]: \(oneValuerepeatedInt64)\n"
-          repeatedInt64ElementIndex++
+          repeatedInt64ElementIndex += 1
       }
       var repeatedUint32ElementIndex:Int = 0
       for oneValuerepeatedUint32 in repeatedUint32  {
           output += "\(indent) repeatedUint32[\(repeatedUint32ElementIndex)]: \(oneValuerepeatedUint32)\n"
-          repeatedUint32ElementIndex++
+          repeatedUint32ElementIndex += 1
       }
       var repeatedUint64ElementIndex:Int = 0
       for oneValuerepeatedUint64 in repeatedUint64  {
           output += "\(indent) repeatedUint64[\(repeatedUint64ElementIndex)]: \(oneValuerepeatedUint64)\n"
-          repeatedUint64ElementIndex++
+          repeatedUint64ElementIndex += 1
       }
       var repeatedSint32ElementIndex:Int = 0
       for oneValuerepeatedSint32 in repeatedSint32  {
           output += "\(indent) repeatedSint32[\(repeatedSint32ElementIndex)]: \(oneValuerepeatedSint32)\n"
-          repeatedSint32ElementIndex++
+          repeatedSint32ElementIndex += 1
       }
       var repeatedSint64ElementIndex:Int = 0
       for oneValuerepeatedSint64 in repeatedSint64  {
           output += "\(indent) repeatedSint64[\(repeatedSint64ElementIndex)]: \(oneValuerepeatedSint64)\n"
-          repeatedSint64ElementIndex++
+          repeatedSint64ElementIndex += 1
       }
       var repeatedFixed32ElementIndex:Int = 0
       for oneValuerepeatedFixed32 in repeatedFixed32  {
           output += "\(indent) repeatedFixed32[\(repeatedFixed32ElementIndex)]: \(oneValuerepeatedFixed32)\n"
-          repeatedFixed32ElementIndex++
+          repeatedFixed32ElementIndex += 1
       }
       var repeatedFixed64ElementIndex:Int = 0
       for oneValuerepeatedFixed64 in repeatedFixed64  {
           output += "\(indent) repeatedFixed64[\(repeatedFixed64ElementIndex)]: \(oneValuerepeatedFixed64)\n"
-          repeatedFixed64ElementIndex++
+          repeatedFixed64ElementIndex += 1
       }
       var repeatedSfixed32ElementIndex:Int = 0
       for oneValuerepeatedSfixed32 in repeatedSfixed32  {
           output += "\(indent) repeatedSfixed32[\(repeatedSfixed32ElementIndex)]: \(oneValuerepeatedSfixed32)\n"
-          repeatedSfixed32ElementIndex++
+          repeatedSfixed32ElementIndex += 1
       }
       var repeatedSfixed64ElementIndex:Int = 0
       for oneValuerepeatedSfixed64 in repeatedSfixed64  {
           output += "\(indent) repeatedSfixed64[\(repeatedSfixed64ElementIndex)]: \(oneValuerepeatedSfixed64)\n"
-          repeatedSfixed64ElementIndex++
+          repeatedSfixed64ElementIndex += 1
       }
       var repeatedFloatElementIndex:Int = 0
       for oneValuerepeatedFloat in repeatedFloat  {
           output += "\(indent) repeatedFloat[\(repeatedFloatElementIndex)]: \(oneValuerepeatedFloat)\n"
-          repeatedFloatElementIndex++
+          repeatedFloatElementIndex += 1
       }
       var repeatedDoubleElementIndex:Int = 0
       for oneValuerepeatedDouble in repeatedDouble  {
           output += "\(indent) repeatedDouble[\(repeatedDoubleElementIndex)]: \(oneValuerepeatedDouble)\n"
-          repeatedDoubleElementIndex++
+          repeatedDoubleElementIndex += 1
       }
       var repeatedBoolElementIndex:Int = 0
       for oneValuerepeatedBool in repeatedBool  {
           output += "\(indent) repeatedBool[\(repeatedBoolElementIndex)]: \(oneValuerepeatedBool)\n"
-          repeatedBoolElementIndex++
+          repeatedBoolElementIndex += 1
       }
       var repeatedStringElementIndex:Int = 0
       for oneValuerepeatedString in repeatedString  {
           output += "\(indent) repeatedString[\(repeatedStringElementIndex)]: \(oneValuerepeatedString)\n"
-          repeatedStringElementIndex++
+          repeatedStringElementIndex += 1
       }
       var repeatedBytesElementIndex:Int = 0
       for oneValuerepeatedBytes in repeatedBytes  {
           output += "\(indent) repeatedBytes[\(repeatedBytesElementIndex)]: \(oneValuerepeatedBytes)\n"
-          repeatedBytesElementIndex++
+          repeatedBytesElementIndex += 1
       }
       var repeatedGroupElementIndex:Int = 0
       for oneElementrepeatedGroup in repeatedGroup {
           output += "\(indent) repeatedGroup[\(repeatedGroupElementIndex)] {\n"
           output += try oneElementrepeatedGroup.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedGroupElementIndex++
+          repeatedGroupElementIndex += 1
       }
       var repeatedNestedMessageElementIndex:Int = 0
       for oneElementrepeatedNestedMessage in repeatedNestedMessage {
           output += "\(indent) repeatedNestedMessage[\(repeatedNestedMessageElementIndex)] {\n"
           output += try oneElementrepeatedNestedMessage.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedNestedMessageElementIndex++
+          repeatedNestedMessageElementIndex += 1
       }
       var repeatedForeignMessageElementIndex:Int = 0
       for oneElementrepeatedForeignMessage in repeatedForeignMessage {
           output += "\(indent) repeatedForeignMessage[\(repeatedForeignMessageElementIndex)] {\n"
           output += try oneElementrepeatedForeignMessage.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedForeignMessageElementIndex++
+          repeatedForeignMessageElementIndex += 1
       }
       var repeatedImportMessageElementIndex:Int = 0
       for oneElementrepeatedImportMessage in repeatedImportMessage {
           output += "\(indent) repeatedImportMessage[\(repeatedImportMessageElementIndex)] {\n"
           output += try oneElementrepeatedImportMessage.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedImportMessageElementIndex++
+          repeatedImportMessageElementIndex += 1
       }
       var repeatedNestedEnumElementIndex:Int = 0
       for oneValueOfrepeatedNestedEnum in repeatedNestedEnum {
           output += "\(indent) repeatedNestedEnum[\(repeatedNestedEnumElementIndex)]: \(oneValueOfrepeatedNestedEnum.rawValue)\n"
-          repeatedNestedEnumElementIndex++
+          repeatedNestedEnumElementIndex += 1
       }
       var repeatedForeignEnumElementIndex:Int = 0
       for oneValueOfrepeatedForeignEnum in repeatedForeignEnum {
           output += "\(indent) repeatedForeignEnum[\(repeatedForeignEnumElementIndex)]: \(oneValueOfrepeatedForeignEnum.rawValue)\n"
-          repeatedForeignEnumElementIndex++
+          repeatedForeignEnumElementIndex += 1
       }
       var repeatedImportEnumElementIndex:Int = 0
       for oneValueOfrepeatedImportEnum in repeatedImportEnum {
           output += "\(indent) repeatedImportEnum[\(repeatedImportEnumElementIndex)]: \(oneValueOfrepeatedImportEnum.rawValue)\n"
-          repeatedImportEnumElementIndex++
+          repeatedImportEnumElementIndex += 1
       }
       var repeatedStringPieceElementIndex:Int = 0
       for oneValuerepeatedStringPiece in repeatedStringPiece  {
           output += "\(indent) repeatedStringPiece[\(repeatedStringPieceElementIndex)]: \(oneValuerepeatedStringPiece)\n"
-          repeatedStringPieceElementIndex++
+          repeatedStringPieceElementIndex += 1
       }
       var repeatedCordElementIndex:Int = 0
       for oneValuerepeatedCord in repeatedCord  {
           output += "\(indent) repeatedCord[\(repeatedCordElementIndex)]: \(oneValuerepeatedCord)\n"
-          repeatedCordElementIndex++
+          repeatedCordElementIndex += 1
       }
       var repeatedLazyMessageElementIndex:Int = 0
       for oneElementrepeatedLazyMessage in repeatedLazyMessage {
           output += "\(indent) repeatedLazyMessage[\(repeatedLazyMessageElementIndex)] {\n"
           output += try oneElementrepeatedLazyMessage.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedLazyMessageElementIndex++
+          repeatedLazyMessageElementIndex += 1
       }
       if hasDefaultInt32 {
         output += "\(indent) defaultInt32: \(defaultInt32) \n"
@@ -6315,72 +6315,72 @@ internal extension ProtobufUnittest {
       var packedInt32ElementIndex:Int = 0
       for oneValuepackedInt32 in packedInt32  {
           output += "\(indent) packedInt32[\(packedInt32ElementIndex)]: \(oneValuepackedInt32)\n"
-          packedInt32ElementIndex++
+          packedInt32ElementIndex += 1
       }
       var packedInt64ElementIndex:Int = 0
       for oneValuepackedInt64 in packedInt64  {
           output += "\(indent) packedInt64[\(packedInt64ElementIndex)]: \(oneValuepackedInt64)\n"
-          packedInt64ElementIndex++
+          packedInt64ElementIndex += 1
       }
       var packedUint32ElementIndex:Int = 0
       for oneValuepackedUint32 in packedUint32  {
           output += "\(indent) packedUint32[\(packedUint32ElementIndex)]: \(oneValuepackedUint32)\n"
-          packedUint32ElementIndex++
+          packedUint32ElementIndex += 1
       }
       var packedUint64ElementIndex:Int = 0
       for oneValuepackedUint64 in packedUint64  {
           output += "\(indent) packedUint64[\(packedUint64ElementIndex)]: \(oneValuepackedUint64)\n"
-          packedUint64ElementIndex++
+          packedUint64ElementIndex += 1
       }
       var packedSint32ElementIndex:Int = 0
       for oneValuepackedSint32 in packedSint32  {
           output += "\(indent) packedSint32[\(packedSint32ElementIndex)]: \(oneValuepackedSint32)\n"
-          packedSint32ElementIndex++
+          packedSint32ElementIndex += 1
       }
       var packedSint64ElementIndex:Int = 0
       for oneValuepackedSint64 in packedSint64  {
           output += "\(indent) packedSint64[\(packedSint64ElementIndex)]: \(oneValuepackedSint64)\n"
-          packedSint64ElementIndex++
+          packedSint64ElementIndex += 1
       }
       var packedFixed32ElementIndex:Int = 0
       for oneValuepackedFixed32 in packedFixed32  {
           output += "\(indent) packedFixed32[\(packedFixed32ElementIndex)]: \(oneValuepackedFixed32)\n"
-          packedFixed32ElementIndex++
+          packedFixed32ElementIndex += 1
       }
       var packedFixed64ElementIndex:Int = 0
       for oneValuepackedFixed64 in packedFixed64  {
           output += "\(indent) packedFixed64[\(packedFixed64ElementIndex)]: \(oneValuepackedFixed64)\n"
-          packedFixed64ElementIndex++
+          packedFixed64ElementIndex += 1
       }
       var packedSfixed32ElementIndex:Int = 0
       for oneValuepackedSfixed32 in packedSfixed32  {
           output += "\(indent) packedSfixed32[\(packedSfixed32ElementIndex)]: \(oneValuepackedSfixed32)\n"
-          packedSfixed32ElementIndex++
+          packedSfixed32ElementIndex += 1
       }
       var packedSfixed64ElementIndex:Int = 0
       for oneValuepackedSfixed64 in packedSfixed64  {
           output += "\(indent) packedSfixed64[\(packedSfixed64ElementIndex)]: \(oneValuepackedSfixed64)\n"
-          packedSfixed64ElementIndex++
+          packedSfixed64ElementIndex += 1
       }
       var packedFloatElementIndex:Int = 0
       for oneValuepackedFloat in packedFloat  {
           output += "\(indent) packedFloat[\(packedFloatElementIndex)]: \(oneValuepackedFloat)\n"
-          packedFloatElementIndex++
+          packedFloatElementIndex += 1
       }
       var packedDoubleElementIndex:Int = 0
       for oneValuepackedDouble in packedDouble  {
           output += "\(indent) packedDouble[\(packedDoubleElementIndex)]: \(oneValuepackedDouble)\n"
-          packedDoubleElementIndex++
+          packedDoubleElementIndex += 1
       }
       var packedBoolElementIndex:Int = 0
       for oneValuepackedBool in packedBool  {
           output += "\(indent) packedBool[\(packedBoolElementIndex)]: \(oneValuepackedBool)\n"
-          packedBoolElementIndex++
+          packedBoolElementIndex += 1
       }
       var packedEnumElementIndex:Int = 0
       for oneValueOfpackedEnum in packedEnum {
           output += "\(indent) packedEnum[\(packedEnumElementIndex)]: \(oneValueOfpackedEnum.rawValue)\n"
-          packedEnumElementIndex++
+          packedEnumElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output
@@ -8586,49 +8586,49 @@ internal extension ProtobufUnittest {
               output += "\(indent) field1[\(field1ElementIndex)] {\n"
               output += try oneElementfield1.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              field1ElementIndex++
+              field1ElementIndex += 1
           }
           var field2ElementIndex:Int = 0
           for oneElementfield2 in field2 {
               output += "\(indent) field2[\(field2ElementIndex)] {\n"
               output += try oneElementfield2.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              field2ElementIndex++
+              field2ElementIndex += 1
           }
           var field3ElementIndex:Int = 0
           for oneElementfield3 in field3 {
               output += "\(indent) field3[\(field3ElementIndex)] {\n"
               output += try oneElementfield3.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              field3ElementIndex++
+              field3ElementIndex += 1
           }
           var group1ElementIndex:Int = 0
           for oneElementgroup1 in group1 {
               output += "\(indent) group1[\(group1ElementIndex)] {\n"
               output += try oneElementgroup1.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              group1ElementIndex++
+              group1ElementIndex += 1
           }
           var group2ElementIndex:Int = 0
           for oneElementgroup2 in group2 {
               output += "\(indent) group2[\(group2ElementIndex)] {\n"
               output += try oneElementgroup2.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              group2ElementIndex++
+              group2ElementIndex += 1
           }
           var ext1ElementIndex:Int = 0
           for oneElementext1 in ext1 {
               output += "\(indent) ext1[\(ext1ElementIndex)] {\n"
               output += try oneElementext1.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              ext1ElementIndex++
+              ext1ElementIndex += 1
           }
           var ext2ElementIndex:Int = 0
           for oneElementext2 in ext2 {
               output += "\(indent) ext2[\(ext2ElementIndex)] {\n"
               output += try oneElementext2.getDescription("\(indent)  ")
               output += "\(indent)}\n"
-              ext2ElementIndex++
+              ext2ElementIndex += 1
           }
           output += unknownFields.getDescription(indent)
           return output
@@ -9539,7 +9539,7 @@ internal extension ProtobufUnittest {
           output += "\(indent) repeatedAllTypes[\(repeatedAllTypesElementIndex)] {\n"
           output += try oneElementrepeatedAllTypes.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedAllTypesElementIndex++
+          repeatedAllTypesElementIndex += 1
       }
       if hasOptionalGroup {
         output += "\(indent) optionalGroup {\n"
@@ -9553,7 +9553,7 @@ internal extension ProtobufUnittest {
           output += "\(indent) repeatedGroup[\(repeatedGroupElementIndex)] {\n"
           output += try oneElementrepeatedGroup.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          repeatedGroupElementIndex++
+          repeatedGroupElementIndex += 1
       }
       output += try getExtensionDescription(Int32(1000), endExclusive:Int32(536870912), indent:indent)
       output += unknownFields.getDescription(indent)

--- a/plugin/ProtocolBuffers/ProtocolBuffersTests/pbTests/ProtobufUnittest.UnittestMset.proto.swift
+++ b/plugin/ProtocolBuffers/ProtocolBuffersTests/pbTests/ProtobufUnittest.UnittestMset.proto.swift
@@ -1256,7 +1256,7 @@ internal extension ProtobufUnittest {
           output += "\(indent) item[\(itemElementIndex)] {\n"
           output += try oneElementitem.getDescription("\(indent)  ")
           output += "\(indent)}\n"
-          itemElementIndex++
+          itemElementIndex += 1
       }
       output += unknownFields.getDescription(indent)
       return output


### PR DESCRIPTION
Removal of all pre- and post increment operators to conform with Swift 2.2 (deprecated) and Swift 3.0 (removed). PR is mostly what the Xcode's (7.3 beta 7D129n) Swift migration tool would have done.

Tests have also been updated and run without errors. 