### PR TITLE
Fix misplaced class prefix in big hierarchies

### DIFF
--- a/plugin/compiler/swift_helpers.cc
+++ b/plugin/compiler/swift_helpers.cc
@@ -315,11 +315,11 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
     
     string ClassNameWorker(const Descriptor* descriptor) {
         string name = "";
-        name += FileClassPrefix(descriptor->file());
         if (descriptor->containing_type() != NULL) {
-            name = ClassNameWorker(descriptor->containing_type());
+            name += ClassNameWorker(descriptor->containing_type());
             name += ".";
         }
+        name += FileClassPrefix(descriptor->file());
         return CheckReservedNames(name + UnderscoresToCapitalizedCamelCase(descriptor->name()));
     }
     ////


### PR DESCRIPTION
For example, if the class prefix is "Proto", this changes `ProtoProtoXXX.YYY.ProtoZZZ` to `ProtoXXX.ProtoYYY.ProtoZZZ`.