### PR TITLE
Fixes using reserved words in enums, by surrounding them with backticks.

### DIFF
--- a/plugin/compiler/swift_enum.cc
+++ b/plugin/compiler/swift_enum.cc
@@ -78,7 +78,7 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
                 }
             }
 
-            printer->Print("case $name$ = $value$\n",
+            printer->Print("case `$name$` = $value$\n",
                            "name", EnumValueName(canonical_values_[i]),
                            "value", SimpleItoa(canonical_values_[i]->number()));
         }


### PR DESCRIPTION
Could conditionally put backticks only around reserved words, but that requires a list of reserved words somewhere, and it doesn't hurt to put backticks around everything.

For example, an enum case "DEFAULT" in proto turned into "Default" in Swift 2, but "default" in Swift 3. This seems to be a keyword inside an enum declaration, so causes errors. Note that accessing it with .default after it has been declared works fine - so users of the generated code never need to use backticks themselves.