### PR TITLE
Swift 3 – check for reserved words in enum and oneof names

### DIFF
--- a/plugin/ProtocolBuffers/ProtocolBuffers.xcodeproj/project.pbxproj
+++ b/plugin/ProtocolBuffers/ProtocolBuffers.xcodeproj/project.pbxproj
@@ -167,6 +167,10 @@
 		3FF2DCBE1A1A681A00226761 /* golden_packed_fields_message in Resources */ = {isa = PBXBuildFile; fileRef = 3F93013C1A0964ED00F7A20B /* golden_packed_fields_message */; };
 		3FF2DCBF1A1A681A00226761 /* text_format_unittest_data.txt in Resources */ = {isa = PBXBuildFile; fileRef = 3F93013D1A0964ED00F7A20B /* text_format_unittest_data.txt */; };
 		3FF2DCC01A1A681A00226761 /* text_format_unittest_extensions_data.txt in Resources */ = {isa = PBXBuildFile; fileRef = 3F93013E1A0964ED00F7A20B /* text_format_unittest_extensions_data.txt */; };
+		A5EDD56C1D51B14C00E4B1F6 /* Google.Protobuf.Any.proto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F586C371D50EE720015E6F5 /* Google.Protobuf.Any.proto.swift */; };
+		A5EDD56D1D51B14D00E4B1F6 /* Google.Protobuf.Any.proto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F586C371D50EE720015E6F5 /* Google.Protobuf.Any.proto.swift */; };
+		A5EDD56E1D51B15000E4B1F6 /* Google.Protobuf.Type.proto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F586C381D50EE720015E6F5 /* Google.Protobuf.Type.proto.swift */; };
+		A5EDD56F1D51B15000E4B1F6 /* Google.Protobuf.Type.proto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F586C381D50EE720015E6F5 /* Google.Protobuf.Type.proto.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -755,6 +759,8 @@
 				3F89A83D1C396BD8009876B8 /* Google.Protobuf.Descriptor.proto.swift in Sources */,
 				3F89A8411C396BD8009876B8 /* Google.Protobuf.SourceContext.proto.swift in Sources */,
 				3F89A8461C396BD8009876B8 /* Google.Protobuf.Wrappers.proto.swift in Sources */,
+				A5EDD56E1D51B15000E4B1F6 /* Google.Protobuf.Type.proto.swift in Sources */,
+				A5EDD56D1D51B14D00E4B1F6 /* Google.Protobuf.Any.proto.swift in Sources */,
 				3F89A8331C396BD8009876B8 /* AbstractMessage.swift in Sources */,
 				3F89A8431C396BD8009876B8 /* Google.Protobuf.SwiftDescriptor.proto.swift in Sources */,
 				3F89A8401C396BD8009876B8 /* Google.Protobuf.FieldMask.proto.swift in Sources */,
@@ -783,6 +789,8 @@
 				3F89A8261C396BD6009876B8 /* Google.Protobuf.Descriptor.proto.swift in Sources */,
 				3F89A82A1C396BD6009876B8 /* Google.Protobuf.SourceContext.proto.swift in Sources */,
 				3F89A82F1C396BD6009876B8 /* Google.Protobuf.Wrappers.proto.swift in Sources */,
+				A5EDD56F1D51B15000E4B1F6 /* Google.Protobuf.Type.proto.swift in Sources */,
+				A5EDD56C1D51B14C00E4B1F6 /* Google.Protobuf.Any.proto.swift in Sources */,
 				3F89A81C1C396BD6009876B8 /* AbstractMessage.swift in Sources */,
 				3F89A82C1C396BD6009876B8 /* Google.Protobuf.SwiftDescriptor.proto.swift in Sources */,
 				3F89A8291C396BD6009876B8 /* Google.Protobuf.FieldMask.proto.swift in Sources */,

--- a/plugin/compiler/swift_helpers.cc
+++ b/plugin/compiler/swift_helpers.cc
@@ -606,7 +606,7 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
             name = "`" + name + "`";
         }
         name[0] = tolower(name[0]);
-        return name;
+        return CheckReservedNames(name);
     }
 
 

--- a/plugin/compiler/swift_message_field.cc
+++ b/plugin/compiler/swift_message_field.cc
@@ -221,7 +221,7 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
     void MessageFieldGenerator::GenerateSerializedSizeCodeSource(io::Printer* printer) const {
         printer->Print(variables_,
                        "if has$capitalized_name$ {\n"
-                       "    if let varSize$name_reserved$ = $name_reserved$?.compute$group_or_message$Size(fieldNumber: $number$) {\n"
+                       "    if let varSize$name$ = $name_reserved$?.compute$group_or_message$Size(fieldNumber: $number$) {\n"
                        "        serialize_size += varSize$name$\n"
                        "    }\n"
                        "}\n");

--- a/plugin/compiler/swift_oneof.cc
+++ b/plugin/compiler/swift_oneof.cc
@@ -77,7 +77,7 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
         string acControl = GetAccessControlType(descriptor_->containing_type()->file());
 
         printer->Print("$acontrol$ enum $classname$ {\n",
-                       "classname",UnderscoresToCapitalizedCamelCase(descriptor_->name()),
+                       "classname",CheckReservedNames(UnderscoresToCapitalizedCamelCase(descriptor_->name())),
                        "acontrol", acControl);
         
         
@@ -94,7 +94,7 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
                        "     }\n"
                        "}\n",
                        "classname",UnderscoresToCapitalizedCamelCase(descriptor_->name()),
-                       "name",UnderscoresToCapitalizedCamelCase(descriptor_->name()),
+                       "name",CheckReservedNames(UnderscoresToCapitalizedCamelCase(descriptor_->name())),
                       "acontrol", acControl);
         
         printer->Outdent();
@@ -108,7 +108,7 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
                 
                 string classNames = ClassNameReturedType(fieldType->message_type());
                 printer->Print("case $name$($type$)\n\n",
-                               "name",UnderscoresToCapitalizedCamelCase(fieldType),
+                               "name",CheckReservedNames(UnderscoresToCapitalizedCamelCase(fieldType)),
                                "type",classNames);
                 
                 
@@ -131,7 +131,7 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
                 const FieldDescriptor* enumDesc = descriptor_->field(i);
                 string type = ClassNameReturedType(enumDesc->enum_type());
                 printer->Print("case $name$($type$)\n\n",
-                               "name",UnderscoresToCapitalizedCamelCase(enumDesc->name()),
+                               "name",CheckReservedNames(UnderscoresToCapitalizedCamelCase(enumDesc->name())),
                                "type",type);
                 
                 printer->Print("$acontrol$ ","acontrol", acControl);
@@ -150,7 +150,7 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
             else
             {
                 printer->Print("case $name$($type$)\n\n",
-                               "name",UnderscoresToCapitalizedCamelCase(fieldType->name()),
+                               "name",CheckReservedNames(UnderscoresToCapitalizedCamelCase(fieldType->name())),
                                "type",PrimitiveTypeName(fieldType));
                 
                 printer->Print("$acontrol$ ","acontrol", acControl);


### PR DESCRIPTION
* Check for reserved words in enum and oneof names
* Fixed generation of varSize$name$ in hasX methods
* Fixed building on macOS – added some generated .swift Source files that got left out of macOS and watchOS builds

I’m a little confused by some of the code – it looks like there was already a system for checking for reserved words – using the SafeName function that checks kKeywordList (which only contains "TYPE_BOOL"?). But this system is only used by enums.

Looks like the code could still do with some cleanup. This kKeywordList (seems originally copy/pasted from the protobuf CPP implementation) could be a slightly more efficient system, as it uses a hash table for searching, instead of a linear search through an array.