### PR TITLE
Fix making Enum Value Names safe.

### DIFF
--- a/plugin/compiler/swift_helpers.cc
+++ b/plugin/compiler/swift_helpers.cc
@@ -497,13 +497,16 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
         return SafeName(name);
     }
 
-    //Swift bug: when enumName == enaumFieldName
     string EnumValueName(const EnumValueDescriptor* descriptor) {
-        string name = UnderscoresToCapitalizedCamelCase(SafeName(descriptor->name()));
+        string name = descriptor->name();
+        name = UnderscoresToCapitalizedCamelCase(name);
+        name[0] = tolower(name[0]);
+        name = SafeName(name); // must check if safe after all transformations
+
+        //Swift bug: when enumName == enaumFieldName
         if (name == UnderscoresToCapitalizedCamelCase(descriptor->type()->name()) || name == "String") {
             name = "`" + name + "`";
         }
-        name[0] = tolower(name[0]);
         return name;
     }
 


### PR DESCRIPTION
Need to run through SafeName function after all other transformation are complete. (eg. previously "Default" name looks safe, but is made lowercase "default" afterwards, which is no longer safe)

Related to #164 