### PR TITLE
Fix escaping Enum methods return type

### DIFF
--- a/plugin/compiler/swift_helpers.cc
+++ b/plugin/compiler/swift_helpers.cc
@@ -497,13 +497,16 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
         return SafeName(name);
     }
 
-    //Swift bug: when enumName == enaumFieldName
     string EnumValueName(const EnumValueDescriptor* descriptor) {
-        string name = UnderscoresToCapitalizedCamelCase(SafeName(descriptor->name()));
+        string name = descriptor->name();
+        name = UnderscoresToCapitalizedCamelCase(name);
+        name[0] = tolower(name[0]);
+        name = SafeName(name); // must check if safe after all transformations
+
+        //Swift bug: when enumName == enaumFieldName
         if (name == UnderscoresToCapitalizedCamelCase(descriptor->type()->name()) || name == "String") {
             name = "`" + name + "`";
         }
-        name[0] = tolower(name[0]);
         return name;
     }
 

--- a/plugin/compiler/swift_helpers.cc
+++ b/plugin/compiler/swift_helpers.cc
@@ -401,7 +401,7 @@ namespace google { namespace protobuf { namespace compiler { namespace swift {
         }
    
         name += FileClassPrefix(descriptor->file());
-        name += SafeName(UnderscoresToCapitalizedCamelCase(descriptor->name()));
+        name += UnderscoresToCapitalizedCamelCase(descriptor->name());
         return SafeName(name);
         
     }


### PR DESCRIPTION
Wow, @alexeyxo was quick! Here’s one more related come, that should fix #172 