### PR TITLE
Improved performance of initialization of CodedInputStream

### DIFF
--- a/Source/CodedInputStream.swift
+++ b/Source/CodedInputStream.swift
@@ -34,7 +34,9 @@ public class CodedInputStream {
     fileprivate var recursionLimit:Int = 0
     fileprivate var sizeLimit:Int = 0
     public init (data:Data) {
-        buffer = [UInt8](data)
+        buffer = data.withUnsafeBytes {
+            [UInt8](UnsafeBufferPointer(start: $0, count: data.count))
+        }
         bufferSize = buffer.count
         currentLimit = Int.max
         recursionLimit = DEFAULT_RECURSION_LIMIT


### PR DESCRIPTION
Hi,

your project is great! I could not handle Protocol Buffers without it.
I just discovered that a lot of performance is lost in the initialization of `CodedInputStream`.
If you are transmitting a huge number of messages, the initialization of the buffer uses most of the total CPU time. This initialization with a pointer should fix it.

Kind regards,
Christian