### PR TITLE
Eliminate ambiguous use of `UnsafeRawPointer` init.  Fixes #239 and #240.

### DIFF
--- a/Source/CodedInputStream.swift
+++ b/Source/CodedInputStream.swift
@@ -480,8 +480,7 @@ public class CodedInputStream {
     public func readData() throws -> Data {
         let size = Int(try readRawVarint32())
         if size < bufferSize - bufferPos && size > 0 {
-//            let pointer = UnsafeMutablePointerInt8From(data: buffer)
-            let unsafeRaw = UnsafeRawPointer(&buffer+bufferPos)
+            let unsafeRaw: UnsafeRawPointer = &buffer+bufferPos
             let data = Data(bytes: unsafeRaw, count: size)
             bufferPos += size
             return data


### PR DESCRIPTION
I verified this builds successfully in both Xcode 10 beta and 9.4.1.