### PR TITLE
protobuf 3.8 support: no wire_format_lite_inl.h

### DIFF
--- a/plugin/compiler/google/protobuf/descriptor.pb.cc
+++ b/plugin/compiler/google/protobuf/descriptor.pb.cc
@@ -8,7 +8,11 @@
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/port.h>
 #include <google/protobuf/io/coded_stream.h>
+#if PROTOBUF_VERSION < 3008000
 #include <google/protobuf/wire_format_lite_inl.h>
+#else
+#include <google/protobuf/wire_format_lite.h>
+#endif
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/generated_message_reflection.h>
 #include <google/protobuf/reflection_ops.h>

--- a/plugin/compiler/google/protobuf/swift-descriptor.pb.cc
+++ b/plugin/compiler/google/protobuf/swift-descriptor.pb.cc
@@ -8,7 +8,11 @@
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/port.h>
 #include <google/protobuf/io/coded_stream.h>
+#if PROTOBUF_VERSION < 3008000
 #include <google/protobuf/wire_format_lite_inl.h>
+#else
+#include <google/protobuf/wire_format_lite.h>
+#endif
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/generated_message_reflection.h>
 #include <google/protobuf/reflection_ops.h>

--- a/plugin/compiler/react_native/swift_react.cc
+++ b/plugin/compiler/react_native/swift_react.cc
@@ -23,7 +23,11 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/wire_format.h>
+#if PROTOBUF_VERSION < 3008000
 #include <google/protobuf/wire_format_lite_inl.h>
+#else
+#include <google/protobuf/wire_format_lite.h>
+#endif
 #include <google/protobuf/descriptor.pb.h>
 #include "swift_helpers_react.h"
 #include "swift_helpers.h"

--- a/plugin/compiler/react_native/swift_react_enums.cc
+++ b/plugin/compiler/react_native/swift_react_enums.cc
@@ -23,7 +23,11 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/wire_format.h>
+#if PROTOBUF_VERSION < 3008000
 #include <google/protobuf/wire_format_lite_inl.h>
+#else
+#include <google/protobuf/wire_format_lite.h>
+#endif
 #include <google/protobuf/descriptor.pb.h>
 #include "swift_helpers_react.h"
 #include "swift_helpers.h"

--- a/plugin/compiler/swift_map_field.cc
+++ b/plugin/compiler/swift_map_field.cc
@@ -23,7 +23,11 @@
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/wire_format.h>
+#if PROTOBUF_VERSION < 3008000
 #include <google/protobuf/wire_format_lite_inl.h>
+#else
+#include <google/protobuf/wire_format_lite.h>
+#endif
 #include <google/protobuf/stubs/strutil.h>
 #include <google/protobuf/stubs/substitute.h>
 

--- a/plugin/compiler/swift_message.cc
+++ b/plugin/compiler/swift_message.cc
@@ -24,7 +24,11 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/wire_format.h>
+#if PROTOBUF_VERSION < 3008000
 #include <google/protobuf/wire_format_lite_inl.h>
+#else
+#include <google/protobuf/wire_format_lite.h>
+#endif
 #include <google/protobuf/descriptor.pb.h>
 
 #include "swift_enum.h"

--- a/plugin/compiler/swift_primitive_field.cc
+++ b/plugin/compiler/swift_primitive_field.cc
@@ -23,7 +23,11 @@
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/wire_format.h>
+#if PROTOBUF_VERSION < 3008000
 #include <google/protobuf/wire_format_lite_inl.h>
+#else
+#include <google/protobuf/wire_format_lite.h>
+#endif
 #include <google/protobuf/stubs/strutil.h>
 #include <google/protobuf/stubs/substitute.h>
 


### PR DESCRIPTION
The wire_format_lite_inl.h header file has been deleted from
protobuf 3.8, and the wire_format_lite.h is recommended instead.
See https://github.com/protocolbuffers/protobuf/pull/6196 for
some discussion.

I noticed this after seeing a failed build for protobuf 3.8 in homebrew: https://github.com/Homebrew/homebrew-core/pull/40438